### PR TITLE
MAINT: Fix warning errors on Python3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,7 @@ before_install:
           CONTAINER=wheels;
           UPLOAD_ARGS="--no-update-index";
       fi
+    - CFLAGS=$CFLAGS" -Wno-sign-compare -Wno-unused-result"
     - source multibuild/common_utils.sh
     - source multibuild/travis_steps.sh
     - before_install


### PR DESCRIPTION
Try adding

    - CFLAGS=$CFLAGS" -Wno-sign-compare -Wno-unused-result"

to before_install instructions in .travis.yml