### PR TITLE
MAINT: Fix warning errors on Python3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,16 +56,20 @@ matrix:
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.5
+        - CFLAGS=$CFLAGS" -Wno-sign-compare -Wno-unused-result"
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.5
+        - CFLAGS=$CFLAGS" -Wno-sign-compare -Wno-unused-result"
         - PLAT=i686
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
+        - CFLAGS=$CFLAGS" -Wno-sign-compare -Wno-unused-result"
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
+        - CFLAGS=$CFLAGS" -Wno-sign-compare -Wno-unused-result"
         - PLAT=i686
     - os: osx
       language: generic


### PR DESCRIPTION
Try adding

    - CFLAGS=$CFLAGS" -Wno-sign-compare -Wno-unused-result"

to before_install instructions in .travis.yml