### PR TITLE
NumPy 1.14.3 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ env:
     global:
         - REPO_DIR=numpy
         # Also see DAILY_COMMIT below
-        - BUILD_COMMIT=v1.14.2
+        - BUILD_COMMIT=cfa022f7a02e0e8362cbeb21c2e951d2c6066af5
         - BUILD_DEPENDS="Cython==0.26.1"
         - TEST_DEPENDS=nose
         - PLAT=x86_64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ environment:
       WHEELHOUSE_UPLOADER_SECRET:
         secure:
             9s0gdDGnNnTt7hvyNpn0/ZzOMGPdwPp2SewFTfGzYk7uI+rdAN9rFq2D1gAP4NQh
-      BUILD_COMMIT: v1.14.2
+      BUILD_COMMIT: cfa022f7a02e0e8362cbeb21c2e951d2c6066af5
       DAILY_COMMIT: master
 
   matrix:


### PR DESCRIPTION
1.14.3 wheels build, for after v1.14.3 is tagged. 

(Practice only? Or will merging on github trigger the build?)