### PR TITLE
DEBUG only: probe openblas version available to homebrew on Travis osx image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,6 +110,7 @@ before_install:
     - source multibuild/common_utils.sh
     - source multibuild/travis_steps.sh
     - before_install
+    - ls -tlrh /usr/local/lib/*blas*
     - brew info openblas
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,6 +110,7 @@ before_install:
     - source multibuild/common_utils.sh
     - source multibuild/travis_steps.sh
     - before_install
+    - brew info openblas
 
 install:
     # Maybe get and clean and patch source


### PR DESCRIPTION
This is for debug purposes only -- I want to see what version of `openblas` homebrew has access to on the old osx vm image we're currently using for builds.

Perhaps we are actually getting `0.3.0` from `brew` because of an older local database as suggested as a possibility in https://github.com/numpy/numpy/pull/12457

Or maybe I'm just way off the mark!