### PR TITLE
Update Cython version.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,7 +14,7 @@ environment:
       MINGW_64: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin
       OPENBLAS_32: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-win32-gcc_7_1_0.zip"
       OPENBLAS_64: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-win_amd64-gcc_7_1_0.zip"
-      CYTHON_BUILD_DEP: Cython
+      CYTHON_BUILD_DEP: Cython==0.29.2
       TEST_MODE: fast
       APPVEYOR_SAVE_CACHE_ON_ERROR: true
       APPVEYOR_SKIP_FINALIZE_ON_EXIT: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ env:
         - REPO_DIR=numpy
         # Also see DAILY_COMMIT below
         - BUILD_COMMIT=c9424106d678a05a0520e74d529a448241223f32
-        - BUILD_DEPENDS=cython
+        - BUILD_DEPENDS=cython==0.29.2
         - TEST_DEPENDS=pytest
         - PLAT=x86_64
         - UNICODE_WIDTH=32


### PR DESCRIPTION
Cython >= 0.29.2 is needed to avoid memory leaks.