### PR TITLE
Bump OpenBLAS to v0.3.5 release point

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,8 +12,8 @@ environment:
   global:
       MINGW_32: C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin
       MINGW_64: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin
-      OPENBLAS_32: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-win32-gcc_7_1_0.zip"
-      OPENBLAS_64: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-win_amd64-gcc_7_1_0.zip"
+      OPENBLAS_32: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-win32-gcc_7_1_0.zip"
+      OPENBLAS_64: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-win_amd64-gcc_7_1_0.zip"
       CYTHON_BUILD_DEP: Cython
       TEST_MODE: fast
       APPVEYOR_SAVE_CACHE_ON_ERROR: true

--- a/config.sh
+++ b/config.sh
@@ -7,8 +7,6 @@ function build_wheel {
     local lib_plat=$PLAT
     if [ -n "$IS_OSX" ]; then
         install_gfortran
-        # Use fused openblas library
-        lib_plat="intel"
     fi
     build_libs $lib_plat
     # Fix version error for development wheels by using bdist_wheel

--- a/env_vars.sh
+++ b/env_vars.sh
@@ -1,4 +1,4 @@
 # Environment variables for build
-OPENBLAS_VERSION="v0.3.3-186-g701ea883"
+OPENBLAS_VERSION="v0.3.5"
 MACOSX_DEPLOYMENT_TARGET=10.9
 CFLAGS="-std=c99 -fno-strict-aliasing"


### PR DESCRIPTION
This is motivated by an OpenBLAS-related issue in https://github.com/numpy/numpy/issues/13173, where it was suggested we should bump wheels to use the latest OpenBLAS release point, `v0.3.5`, instead of an earlier development commit on the path to that release (`0.3.5.dev`).

This follows the upstream [merging of the version bump PR for OpenBLAS binaries](https://github.com/MacPython/openblas-libs/pull/1) & the uploads to community server.

