### PR TITLE
MAINT: install gfortran on linux

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -32,6 +32,9 @@ function get_test_cmd {
 function run_tests {
     # Runs tests on installed distribution from an empty directory
     # We only run the 64 bit tests as of NumPy 1.16.
+    if [ -z "$IS_OSX" ]; then
+        apt-get -y update && apt-get install -y gfortran
+    fi
     python -c "$(get_test_cmd)"
     # Check bundled license file
     python ../check_license.py


### PR DESCRIPTION
Related to #22, at least for Linux--both 32 and 64-bit Docker containers seem to be missing `gfortran` there. Mac doesn't seem to have this problem at the moment.

If this works, all linux tests should adjust from having 500+ skips to a more reasonable number of skips, irrespective of the sporadic failure or 32/64-bit status.

I also find the comment above my changes to be confusing:

> We only run the 64 bit tests as of NumPy 1.16.

Especially since I've been trying to debug the sporadic `Pinv` issue again on a private repo with debug / interactive Travis mode. I'll see if I can figure out what changes are associated with that comment. The `complex64` failure had me thinking about `m32` compile / link flags again as well.

Perhaps the comment refers to Mac, but that is confusing given the context is a more general function.