### PR TITLE
MAINT: Bump OpenBLAS to 0.3.7.dev

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,8 +12,8 @@ environment:
   global:
       MINGW_32: C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin
       MINGW_64: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin
-      OPENBLAS_32: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-win32-gcc_7_1_0.zip"
-      OPENBLAS_64: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-win_amd64-gcc_7_1_0.zip"
+      OPENBLAS_32: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-274-g6a8b4269-win32-gcc_7_1_0.zip"
+      OPENBLAS_64: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-274-g6a8b4269-win_amd64-gcc_7_1_0.zip"
       CYTHON_BUILD_DEP: Cython
       TEST_MODE: fast
       APPVEYOR_SAVE_CACHE_ON_ERROR: true

--- a/env_vars.sh
+++ b/env_vars.sh
@@ -1,4 +1,4 @@
 # Environment variables for build
-OPENBLAS_VERSION="v0.3.5"
+OPENBLAS_VERSION="v0.3.5-274-g6a8b4269"
 MACOSX_DEPLOYMENT_TARGET=10.9
 CFLAGS="-std=c99 -fno-strict-aliasing"


### PR DESCRIPTION
Bump OpenBLAS version based on the (emulated) fix demonstration for SkylakeX NumPy linalg issues in: https://github.com/numpy/numpy/pull/13466

The NumPy release manager may also want to cherry-pick this to the 1.16.x wheels branch if it looks suitable / justified.

* this version of OpenBLAS includes proper
deactivation of problematic AVX routines
reported to cause issues for NumPy linalg
on SkylakeX architecture