### PR TITLE
BUILD: add _distributor_local.py to  preload dll on windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -119,6 +119,10 @@ install:
 build_script:
   - cd numpy
   - git checkout %BUILD_COMMIT%
+  # Create _distributor_init.py
+  - cd ..
+  - python -c "import openblas_support; openblas_support.make_init('numpy')"
+  - cd numpy
   # Append license text relevant for the built wheel
   - type ..\LICENSE_win32.txt >> LICENSE.txt
   - ps: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 *~
+*.swp
 tmp_for_test/
 working/
 downloads/

--- a/openblas_support.py
+++ b/openblas_support.py
@@ -1,0 +1,42 @@
+import os
+import textwrap
+
+def make_init(dirname):
+    '''
+    Create a _distributor_init.py file for OpenBlas
+    '''
+    with open(os.path.join(dirname, '_distributor_init.py'), 'wt') as fid:
+        fid.write(textwrap.dedent("""
+            '''
+            Helper to preload windows dlls to prevent dll not found errors.
+            Once a DLL is preloaded, its namespace is made available to any
+            subsequent DLL. This file originated in the numpy-wheels repo,
+            and is created as part of the scripts that build the wheel.
+            '''
+            import os
+            from ctypes import WinDLL
+            import glob
+            if os.name == 'nt':
+                # convention for storing / loading the DLL from
+                # numpy/.libs/, if present
+                try:
+                    basedir = os.path.dirname(os.path.dirname(__file__))
+                except:
+                    pass
+                else:
+                    libs_dir = os.path.abspath(os.path.join(basedir, '.libs'))
+                    DLL_filenames = []
+                    if os.path.isdir(libs_path):
+                        for filename in glob.glob(os.path.join(libs_dir,
+                                                             '*openblas*dll')):
+                            # NOTE: would it change behavior to load ALL
+                            # DLLs at this path vs. the name restriction?
+                            WinDLL(os.path.abspath(filename))
+                            DLL_filenames.append(filename)
+                if len(DLL_filenames) > 1:
+                    import warnings
+                    warnings.warn("loaded more than 1 DLL from .libs:\\n%s" %
+                              "\\n".join(DLL_filenames),
+                              stacklevel=1)
+    """))
+


### PR DESCRIPTION
Part of the fix for numpy/numpy#13764, the other part (removing code from `numpy/core/__init__.py` and duplicating this code there) has to be done in the numpy repo after this is merged in order to reuse `openblas_support.py` from here.

This creates a `_distributor_local.py` file which is packaged with the wheel (on windows only).

I named the new file `openblas_support.py` in the hope that we can add some of the environment variables to it which might unify some of the travis/appveyor/future azure/ CI behaviour