### PR TITLE
BUG: fix base directory and typo

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -121,7 +121,7 @@ build_script:
   - git checkout %BUILD_COMMIT%
   # Create _distributor_init.py
   - cd ..
-  - python -c "import openblas_support; openblas_support.make_init('numpy')"
+  - python -c "import openblas_support; openblas_support.make_init('numpy/numpy')"
   - cd numpy
   # Append license text relevant for the built wheel
   - type ..\LICENSE_win32.txt >> LICENSE.txt

--- a/openblas_support.py
+++ b/openblas_support.py
@@ -26,7 +26,7 @@ def make_init(dirname):
                 else:
                     libs_dir = os.path.abspath(os.path.join(basedir, '.libs'))
                     DLL_filenames = []
-                    if os.path.isdir(libs_path):
+                    if os.path.isdir(libs_dir):
                         for filename in glob.glob(os.path.join(libs_dir,
                                                              '*openblas*dll')):
                             # NOTE: would it change behavior to load ALL


### PR DESCRIPTION
Fix for #50: it was writing `_distributor_init.py` to the wrong directory. Also fix a typo.

Closes #49