### PR TITLE
BUG: final file location is at numpy root directory

### DIFF
--- a/openblas_support.py
+++ b/openblas_support.py
@@ -20,7 +20,7 @@ def make_init(dirname):
                 # convention for storing / loading the DLL from
                 # numpy/.libs/, if present
                 try:
-                    basedir = os.path.dirname(os.path.dirname(__file__))
+                    basedir = os.path.dirname(__file__)
                 except:
                     pass
                 else:


### PR DESCRIPTION
Closes #49 (third time is the charm).

copy-paste error.
The `_distributor_init.py` file is at the root directory, the original code was one directory down.