### PR TITLE
Update to xcode 10.1, add test dependency on pytz

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
         # Also see DAILY_COMMIT below
         - BUILD_COMMIT=master
         - BUILD_DEPENDS=cython
-        - TEST_DEPENDS=pytest
+        - TEST_DEPENDS="pytest pytz"
         - PLAT=x86_64
         - UNICODE_WIDTH=32
         - WHEELHOUSE_UPLOADER_USERNAME=travis-worker
@@ -17,14 +17,11 @@ env:
         - EXTRA_ARGV="'--disable-pytest-warnings'"
 
 language: python
-# Default Python version is usually 2.7
-python: 3.5
 sudo: required
 dist: trusty
 services: docker
-# Force xcode 6.4 image to work round
-# https://github.com/python-pillow/pillow-wheels/issues/45
-osx_image: xcode6.4
+# sync with multibuild/.travis.yml 2019-08-21
+osx_image: xcode10.1
 
 matrix:
   exclude:

--- a/env_vars.sh
+++ b/env_vars.sh
@@ -2,3 +2,4 @@
 OPENBLAS_VERSION="v0.3.5-274-g6a8b4269"
 MACOSX_DEPLOYMENT_TARGET=10.9
 CFLAGS="-std=c99 -fno-strict-aliasing"
+ARCH_FLAGS="-arch x86_64"


### PR DESCRIPTION
multibuild uses xcode 10.1

tests need pytz. Isn;t there a "best practices" way to declare test dependencies?