### PR TITLE
set MB_PYTHON_OSX_VER=10.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,14 +56,17 @@ matrix:
       language: generic
       env:
         - MB_PYTHON_VERSION=3.5
+        - MB_PYTHON_OSX_VER=10.9
     - os: osx
       language: generic
       env:
         - MB_PYTHON_VERSION=3.6
+        - MB_PYTHON_OSX_VER=10.9
     - os: osx
       language: generic
       env:
         - MB_PYTHON_VERSION=3.7
+        - MB_PYTHON_OSX_VER=10.9
 
 before_install:
     - if [ "$TRAVIS_BRANCH" == "master" ]; then


### PR DESCRIPTION
Fixes #43 

need to check that the artifact name in fact does not contain macosx_10_6_intel