### PR TITLE
update multibuild and appveyor to Python3.8.0 final

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -42,11 +42,11 @@ environment:
       PYTHON_VERSION: 3.7
       PYTHON_ARCH: 64
 
-    - PYTHON: C:\Python38rc1
+    - PYTHON: C:\Python38
       PYTHON_VERSION: 3.8
       PYTHON_ARCH: 32
 
-    - PYTHON: C:\Python38rc1-x64
+    - PYTHON: C:\Python38-x64
       PYTHON_VERSION: 3.8
       PYTHON_ARCH: 64
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "numpy"]
 	path = numpy
-	url = git://github.com/numpy/numpy.git
+	url = https://github.com/numpy/numpy.git
 [submodule "multibuild"]
 	path = multibuild
 	url = https://github.com/matthew-brett/multibuild


### PR DESCRIPTION
Python 3.8 was released and multibuild (and manylinux) support it. Upgrade to it.