### PR TITLE
Use manylinux2010 instead of default manylinux1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,23 +31,29 @@ matrix:
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
+        - MB_ML_VER=2010
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
+        - MB_ML_VER=2010
         - PLAT=i686
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.7
+        - MB_ML_VER=2010
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.7
+        - MB_ML_VER=2010
         - PLAT=i686
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.8
+        - MB_ML_VER=2010
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.8
+        - MB_ML_VER=2010
         - PLAT=i686
     - os: osx
       language: generic


### PR DESCRIPTION
This is to check out the downstream response. Note that pip >= 19.0 is required, but for nightly builds this may not have an effect because there are already manylinux1 wheels available. Perhaps we should delete them? We many want to upload both manylinux versions after the 1.19.0 release if there are excessive pip problems.