### PR TITLE
WIP: remove -msse2 from linux32 builds, use explicit build tag

### DIFF
--- a/azure/posix.yml
+++ b/azure/posix.yml
@@ -9,7 +9,7 @@ jobs:
       vmImage: ${{ parameters.vmImage }}
     variables:
       REPO_DIR: "numpy"
-      BUILD_COMMIT: 'f1be9e50ff'  # needed for 32 bit builds, should become 1.18.4
+      BUILD_COMMIT: 'maintenance/1.18.x'
       PLAT: "x86_64"
       CYTHON_BUILD_DEP: "cython==0.29.16"
       NIGHTLY_BUILD_COMMIT: "master"

--- a/azure/posix.yml
+++ b/azure/posix.yml
@@ -97,8 +97,9 @@ jobs:
             ANACONDA_ORG="multibuild-wheels-staging"
             TOKEN="$MAPPED_NUMPY_STAGING_UPLOAD_TOKEN"
           fi
-          if [ "$TOKEN" == "" ]; then
+          if [ "$TOKEN" == "" -o "${TOKEN:0:7}" == "\$(NUMPY" ]; then
             echo "##[warning] Could not find anaconda.org upload token in secret variables"
+            TOKEN=""
           fi
           echo "##vso[task.setvariable variable=TOKEN]$TOKEN"
           echo "##vso[task.setvariable variable=ANACONDA_ORG]$ANACONDA_ORG"

--- a/azure/windows.yml
+++ b/azure/windows.yml
@@ -125,8 +125,9 @@ jobs:
             ANACONDA_ORG="multibuild-wheels-staging"
             TOKEN="$MAPPED_NUMPY_STAGING_UPLOAD_TOKEN"
           fi
-          if [ "$TOKEN" == "" ]; then
+          if [ "$TOKEN" == "" -o "${TOKEN:0:7}" == "\$(NUMPY" ]; then
             echo "##[warning] Could not find anaconda.org upload token in secret variables"
+            TOKEN=""
           fi
           echo "##vso[task.setvariable variable=TOKEN]$TOKEN"
           echo "##vso[task.setvariable variable=ANACONDA_ORG]$ANACONDA_ORG"

--- a/azure/windows.yml
+++ b/azure/windows.yml
@@ -8,7 +8,7 @@ jobs:
     pool:
       vmImage: ${{ parameters.vmImage }}
     variables:
-      BUILD_COMMIT: "v1.18.3"
+      BUILD_COMMIT: 'maintenance/1.18.x'
       NIGHTLY_BUILD_COMMIT: "master"
       JUNITXML: "test-data.xml"
       TEST_DIR: '$(Agent.WorkFolder)/tmp_for_test'

--- a/env_vars_32.sh
+++ b/env_vars_32.sh
@@ -4,4 +4,6 @@
 set -x
 OPENBLAS_VERSION="v0.3.7"
 MACOSX_DEPLOYMENT_TARGET=10.9
-CFLAGS="-msse2 -std=c99 -fno-strict-aliasing"
+# Causes failure for pre-1.19 in np.reciprocal
+# CFLAGS="-msse2 -std=c99 -fno-strict-aliasing"
+CFLAGS="-std=c99 -fno-strict-aliasing"


### PR DESCRIPTION
Checking if removing the -msse2 flag from 32-bit fixes wheel building. Should revert this once the last 1.18 build is done, since the problem is fixed on master and the flag allows faster loops.