### PR TITLE
strip when linking

### DIFF
--- a/env_vars.sh
+++ b/env_vars.sh
@@ -1,4 +1,4 @@
 # Environment variables for build
 OPENBLAS_VERSION="v0.3.7"
 MACOSX_DEPLOYMENT_TARGET=10.9
-CFLAGS="-std=c99 -fno-strict-aliasing $CFLAGS"
+CFLAGS="-std=c99 -fno-strict-aliasing -Wl,--strip-debug"

--- a/env_vars.sh
+++ b/env_vars.sh
@@ -1,4 +1,4 @@
 # Environment variables for build
 OPENBLAS_VERSION="v0.3.7"
 MACOSX_DEPLOYMENT_TARGET=10.9
-CFLAGS="-std=c99 -fno-strict-aliasing"
+CFLAGS="-std=c99 -fno-strict-aliasing $CFLAGS"

--- a/env_vars_32.sh
+++ b/env_vars_32.sh
@@ -6,4 +6,4 @@ OPENBLAS_VERSION="v0.3.7"
 MACOSX_DEPLOYMENT_TARGET=10.9
 # Causes failure for pre-1.19 in np.reciprocal
 # CFLAGS="-msse2 -std=c99 -fno-strict-aliasing"
-CFLAGS="-std=c99 -fno-strict-aliasing"
+CFLAGS="-std=c99 -fno-strict-aliasing $CFLAGS"

--- a/env_vars_32.sh
+++ b/env_vars_32.sh
@@ -5,5 +5,5 @@ set -x
 OPENBLAS_VERSION="v0.3.7"
 MACOSX_DEPLOYMENT_TARGET=10.9
 # Causes failure for pre-1.19 in np.reciprocal
-# CFLAGS="-msse2 -std=c99 -fno-strict-aliasing"
-CFLAGS="-std=c99 -fno-strict-aliasing $CFLAGS"
+# CFLAGS="-msse2 -std=c99 -fno-strict-aliasing -Wl,--strip-debug"
+CFLAGS="-std=c99 -fno-strict-aliasing -Wl,--strip-debug"


### PR DESCRIPTION
we should strip the linux binaries before shipping.  Issue gh-19 assumed that we do not override `CFLAGS`, but we do.