### PR TITLE
add a date to make the dev wheels sortable

### DIFF
--- a/azure/posix.yml
+++ b/azure/posix.yml
@@ -90,7 +90,7 @@ jobs:
 
       - bash: |
           set -e
-          if [ "$BUILD_REASON" == "Schedule" ]; then
+          if [ "$BUILD_COMMIT" == "master" ]; then
             ANACONDA_ORG="scipy-wheels-nightly"
             TOKEN="$MAPPED_NUMPY_NIGHTLY_UPLOAD_TOKEN"
           else
@@ -111,10 +111,12 @@ jobs:
 
       - bash: |
           set -e
-          # The --force option forces a replacement if the remote file already
-          # exists.
+          source extra_functions.sh
+          for f in wheelhouse/*.whl; do rename_wheel $f; done
+
           echo uploading wheelhouse/*.whl
-          anaconda -t $TOKEN upload --force -u $ANACONDA_ORG wheelhouse/*.whl
+
+          anaconda -t $TOKEN upload -u $ANACONDA_ORG wheelhouse/*.whl
           echo "PyPI-style index: https://pypi.anaconda.org/$ANACONDA_ORG/simple"
         displayName: Upload to anaconda.org (only if secret token is retrieved)
         condition: ne(variables['TOKEN'], '')

--- a/azure/windows.yml
+++ b/azure/windows.yml
@@ -118,7 +118,7 @@ jobs:
 
       - bash: |
           set -e
-          if [ "$BUILD_REASON" == "Schedule" ]; then
+          if [ "$BUILD_COMMIT" == "master" ]; then
             ANACONDA_ORG="scipy-wheels-nightly"
             TOKEN="$MAPPED_NUMPY_NIGHTLY_UPLOAD_TOKEN"
           else
@@ -139,10 +139,12 @@ jobs:
 
       - bash: |
           set -e
-          # The --force option forces a replacement if the remote file already
-          # exists.
+          source extra_functions.sh
+          for f in numpy/dist/numpy-*.whl; do rename_wheel $f; done
+
           echo uploading numpy/dist/numpy-*.whl
-          anaconda -t $TOKEN upload --force -u $ANACONDA_ORG numpy/dist/numpy-*.whl
+
+          anaconda -t $TOKEN upload -u $ANACONDA_ORG numpy/dist/numpy-*.whl
           echo "PyPI-style index: https://pypi.anaconda.org/$ANACONDA_ORG/simple"
         displayName: Upload to anaconda.org (only if secret token is retrieved)
         condition: ne(variables['TOKEN'], '')

--- a/extra_functions.sh
+++ b/extra_functions.sh
@@ -29,6 +29,22 @@ function teardown_test_venv {
             source venv/bin/activate
         fi
     fi
-} 
+}
+
+function rename_wheel {
+    # Call with a name like numpy-1.19.0.dev0+58dbafa-cp37-cp37m-linux_x86_64.whl
+
+    # Add a date after the dev0+ and before the hash in yyymmddHHMMSS format
+    # so pip will pick up the newest build. Try a little to make sure
+    # - the first part ends with 'dev0+'
+    # - the second part starts with a lower case alphanumeric then a '-'
+    # if those conditions are not met, the name will be returned as-is
+
+    newname=$(echo "$1" | sed "s/\(.*dev0+\)\([a-z0-9]*-.*\)/\1$(date '+%Y%m%d%H%M%S_')\2/")
+    if [ "$newname" != "$1" ]; then
+        mv $1 $newname
+    fi
+}
+
 # Work around bug in multibuild
 if [ ! -o PIP_CMD ]; then PIP_CMD="$PYTHON_EXE -m pip"; fi


### PR DESCRIPTION
xref pandas-dev/pandas#33968

I didn;t notice that the wheeluploader used for rackspace modifies the wheel name so that later names will be picked up by pip before earlier ones. Since the wheels now have timetags, there should not be collisions so I also removed the `--force`.