### PR TITLE
use ldflags

### DIFF
--- a/env_vars.sh
+++ b/env_vars.sh
@@ -1,4 +1,5 @@
 # Environment variables for build
 OPENBLAS_VERSION="v0.3.7"
 MACOSX_DEPLOYMENT_TARGET=10.9
-CFLAGS="-std=c99 -fno-strict-aliasing -Wl,--strip-debug"
+CFLAGS="-std=c99 -fno-strict-aliasing"
+LDFLAGS="-Wl,--strip-debug"

--- a/env_vars_32.sh
+++ b/env_vars_32.sh
@@ -5,5 +5,6 @@ set -x
 OPENBLAS_VERSION="v0.3.7"
 MACOSX_DEPLOYMENT_TARGET=10.9
 # Causes failure for pre-1.19 in np.reciprocal
-# CFLAGS="-msse2 -std=c99 -fno-strict-aliasing -Wl,--strip-debug"
-CFLAGS="-std=c99 -fno-strict-aliasing -Wl,--strip-debug"
+# CFLAGS="-msse2 -std=c99 -fno-strict-aliasing"
+CFLAGS="-std=c99 -fno-strict-aliasing"
+LDFLAGS="-Wl,--strip-debug"


### PR DESCRIPTION
Replaces gh-82 : we should strip the linux binaries before shipping. Issue gh-19 assumed that we do not override `CFLAGS`, but we do.

Using a branch on a fork so successful builds are not uploaded