### PR TITLE
only rename wheels that go to scipy-wheels-nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,16 +105,16 @@ after_success:
     # https://travis-ci.org/github/MacPython/numpy-wheels/settings
     # originally generated at
     # anaconda.org/scipy-wheels-nightly/settings/access
-    - if [ "$TRAVIS_BRANCH" == "master" ]; then
+    - if [ "$TRAVIS_BRANCH" == "master" ] ; then
           ANACONDA_ORG="scipy-wheels-nightly";
           TOKEN=${NUMPY_NIGHTLY_UPLOAD_TOKEN};
-          source extra_functions.sh
-          for f in wheelhouse/*.whl; do rename_wheel $f; done
+          source extra_functions.sh;
+          for f in wheelhouse/*.whl; do rename_wheel $f; done;
       else
           ANACONDA_ORG="multibuild-wheels-staging";
           TOKEN=${NUMPY_STAGING_UPLOAD_TOKEN};
       fi
     - pip install git+https://github.com/Anaconda-Server/anaconda-client;
-    - if [ -n "${TOKEN}" ] ;then
+    - if [ -n "${TOKEN}" ] ; then
         anaconda -t ${TOKEN} upload -u ${ANACONDA_ORG} ${TRAVIS_BUILD_DIR}/wheelhouse/*.whl;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,6 +108,8 @@ after_success:
     - if [ "$TRAVIS_BRANCH" == "master" ]; then
           ANACONDA_ORG="scipy-wheels-nightly";
           TOKEN=${NUMPY_NIGHTLY_UPLOAD_TOKEN};
+          source extra_functions.sh
+          for f in wheelhouse/*.whl; do rename_wheel $f; done
       else
           ANACONDA_ORG="multibuild-wheels-staging";
           TOKEN=${NUMPY_STAGING_UPLOAD_TOKEN};

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,5 +116,5 @@ after_success:
       fi
     - pip install git+https://github.com/Anaconda-Server/anaconda-client;
     - if [ -n "${TOKEN}" ] ;then
-        anaconda -t ${TOKEN} upload u ${ANACONDA_ORG} ${TRAVIS_BUILD_DIR}/wheelhouse/*.whl;
+        anaconda -t ${TOKEN} upload -u ${ANACONDA_ORG} ${TRAVIS_BUILD_DIR}/wheelhouse/*.whl;
       fi

--- a/azure/posix.yml
+++ b/azure/posix.yml
@@ -110,8 +110,10 @@ jobs:
 
       - bash: |
           set -e
-          source extra_functions.sh
-          for f in wheelhouse/*.whl; do rename_wheel $f; done
+          if [ $ANACONDA_ORG == "scipy-wheels-nightly" ]; then
+            source extra_functions.sh
+            for f in wheelhouse/*.whl; do rename_wheel $f; done
+          fi
 
           echo uploading wheelhouse/*.whl
 

--- a/azure/windows.yml
+++ b/azure/windows.yml
@@ -138,8 +138,10 @@ jobs:
 
       - bash: |
           set -e
-          source extra_functions.sh
-          for f in numpy/dist/numpy-*.whl; do rename_wheel $f; done
+          if [ $ANACONDA_ORG == "scipy-wheels-nightly" ]; then
+            source extra_functions.sh
+            for f in wheelhouse/*.whl; do rename_wheel $f; done
+          fi
 
           echo uploading numpy/dist/numpy-*.whl
 


### PR DESCRIPTION
missed this in gh-84: we only want to add the date to the wheels at https://anaconda.org/scipy-wheels-nightly/numpy/files, since the ones at https://anaconda.org/multibuild-wheels-staging/numpy/files are meant to be PyPI candidates. Note that since this PR is from a fork, the changes will not be tested.