### PR TITLE
Remove trigger section from azure-pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,9 +7,6 @@ schedules:
     - master
   always: true
 
-trigger:
-- master
-
 pr:
 - master 
 


### PR DESCRIPTION
Removing the trigger section enables triggering on every branch. This was needed for
the 1.19.0rc1 release. Curiously, the numpy/numpy pipeline was triggered instead before
this change.