### PR TITLE
MAINT: Disable TravisCI clone depth.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ dist: bionic
 services: docker
 os: linux
 
+# Disable clone depth to make sure versioneer
+# can find the most recent tag.
+git:
+  depth: false
+
 jobs:
   include:
     - os: linux


### PR DESCRIPTION
This is needed so that versioneer can find the latest tag as the number
of commits in master continue to grow.