### PR TITLE
Pypy rc1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,7 +56,7 @@ jobs:
           ENV_VARS_PATH: "env_vars_32.sh"
           DOCKER_TEST_IMAGE: "multibuild/xenial_{PLAT}"
         pypy_3.7_64:
-          MB_PYTHON_VERSION: "pypy3.7-7.3.2"
+          MB_PYTHON_VERSION: "pypy3.7-7.3.4rc1"
           AZURE_PYTHON_VERSION: "3.7"
           MB_ML_VER: "2010"
           DOCKER_TEST_IMAGE: multibuild/xenial_{PLAT}

--- a/azure/posix.yml
+++ b/azure/posix.yml
@@ -119,7 +119,7 @@ jobs:
       - bash: |
           set -e
           echo uploading wheelhouse/*.whl
-          anaconda -t $TOKEN upload -u $ANACONDA_ORG wheelhouse/*.whl
+          anaconda -t $TOKEN upload --skip -u $ANACONDA_ORG wheelhouse/*.whl
           echo "PyPI-style index: https://pypi.anaconda.org/$ANACONDA_ORG/simple"
         displayName: Upload to anaconda.org (only if secret token is retrieved)
         condition: ne(variables['TOKEN'], '')

--- a/azure/windows.yml
+++ b/azure/windows.yml
@@ -159,7 +159,7 @@ jobs:
       - bash: |
           set -e
           echo uploading numpy/dist/numpy-*.whl
-          anaconda -t $TOKEN upload -u $ANACONDA_ORG numpy/dist/numpy-*.whl
+          anaconda -t $TOKEN upload --skip -u $ANACONDA_ORG numpy/dist/numpy-*.whl
           echo "PyPI-style index: https://pypi.anaconda.org/$ANACONDA_ORG/simple"
         displayName: Upload to anaconda.org (only if secret token is retrieved)
         condition: ne(variables['TOKEN'], '')


### PR DESCRIPTION
- use pypy 7.3.4rc1 to get METH_FASTCALL. It should be officially released by the time we release 1.21
- add `--skip` to avoid anaconda upload errors