### PR TITLE
MAINT: Drop manylinux1 and manylinux2010 wheels in main.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,7 @@ jobs:
       matrix:
         # manylinux 2014
         pypy_3.7_64:
-          MB_PYTHON_VERSION: "pypy3.7-7.3.4rc1"
+          MB_PYTHON_VERSION: "pypy3.7-7.3.5"
           AZURE_PYTHON_VERSION: "3.7"
           MB_ML_VER: "2014"
           DOCKER_TEST_IMAGE: multibuild/xenial_{PLAT}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,59 +49,43 @@ jobs:
       name: linux
       vmImage: ubuntu-18.04
       matrix:
-        py_3.7_32:
-          MB_PYTHON_VERSION: "3.7"
-          PLAT: "i686"
-          MB_ML_VER: "2010"
-          ENV_VARS_PATH: "env_vars_32.sh"
-          DOCKER_TEST_IMAGE: "multibuild/xenial_{PLAT}"
+        # manylinux 2014
         pypy_3.7_64:
           MB_PYTHON_VERSION: "pypy3.7-7.3.4rc1"
           AZURE_PYTHON_VERSION: "3.7"
-          MB_ML_VER: "2010"
+          MB_ML_VER: "2014"
           DOCKER_TEST_IMAGE: multibuild/xenial_{PLAT}
+
+        py_3.7_32:
+          MB_PYTHON_VERSION: "3.7"
+          PLAT: "i686"
+          MB_ML_VER: "2014"
+          ENV_VARS_PATH: "env_vars_32.sh"
+          DOCKER_TEST_IMAGE: "multibuild/xenial_{PLAT}"
         py_3.7_64:
           MB_PYTHON_VERSION: "3.7"
-          MB_ML_VER: "2010"
+          MB_ML_VER: "2014"
+
         py_3.8_32:
           MB_PYTHON_VERSION: "3.8"
           PLAT: "i686"
-          MB_ML_VER: "2010"
+          MB_ML_VER: "2014"
           ENV_VARS_PATH: "env_vars_32.sh"
           DOCKER_TEST_IMAGE: "multibuild/xenial_{PLAT}"
         py_3.8_64:
           MB_PYTHON_VERSION: "3.8"
-          MB_ML_VER: "2010"
-        py_3.9_32manylinux2010:
-          MB_PYTHON_VERSION: "3.9"
-          PLAT: "i686"
-          MB_ML_VER: "2010"
-          ENV_VARS_PATH: "env_vars_32.sh"
-          DOCKER_TEST_IMAGE: "multibuild/xenial_{PLAT}"
-        py_3.9_64manylinux2010:
-          MB_PYTHON_VERSION: "3.9"
-          MB_ML_VER: "2010"
-          DOCKER_TEST_IMAGE: "multibuild/xenial_{PLAT}"
+          MB_ML_VER: "2014"
 
-        # manylinux1 wheels
-        py_3.7_32manylinux1:
-          MB_PYTHON_VERSION: "3.7"
+        py_3.9_32:
+          MB_PYTHON_VERSION: "3.9"
           PLAT: "i686"
-          MB_ML_VER: "1"
+          MB_ML_VER: "2014"
           ENV_VARS_PATH: "env_vars_32.sh"
           DOCKER_TEST_IMAGE: "multibuild/xenial_{PLAT}"
-        py_3.7_64manylinux1:
-          MB_PYTHON_VERSION: "3.7"
-          MB_ML_VER: "1"
-        py_3.8_32manylinux1:
-          MB_PYTHON_VERSION: "3.8"
-          PLAT: "i686"
-          MB_ML_VER: "1"
-          ENV_VARS_PATH: "env_vars_32.sh"
+        py_3.9_64:
+          MB_PYTHON_VERSION: "3.9"
+          MB_ML_VER: "2014"
           DOCKER_TEST_IMAGE: "multibuild/xenial_{PLAT}"
-        py_3.8_64manylinux1:
-          MB_PYTHON_VERSION: "3.8"
-          MB_ML_VER: "1"
 
   - template: azure/posix.yml
     parameters:
@@ -112,11 +96,12 @@ jobs:
           MB_PYTHON_VERSION: "3.7"
         py_3.8_64:
           MB_PYTHON_VERSION: "3.8"
+        py_3.9_64:
+          MB_PYTHON_VERSION: "3.9"
+
         py_3.8_universal2:
           MB_PYTHON_VERSION: "3.8"
           PLAT: universal2
         py_3.9_universal2:
           MB_PYTHON_VERSION: "3.9"
           PLAT: universal2
-        py_3.9_64:
-          MB_PYTHON_VERSION: "3.9"


### PR DESCRIPTION
Start using manylinux2014 for nightly builds in preparation for NumPy 1.22.x.