### PR TITLE
MAINT: Use BLAS ILP64 for 64 bit wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,24 +25,27 @@ jobs:
       arch: arm64
       env:
         - PLAT=aarch64
-        - MB_ML_VER=2014
         - MB_PYTHON_VERSION=3.7
+        - MB_ML_VER=2014
+        #- CONFIG_PATH: "config_ilp64.sh"
         - DEBUG_PRINT=1
         - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
     - os: linux
       arch: arm64
       env:
         - PLAT=aarch64
-        - MB_ML_VER=2014
         - MB_PYTHON_VERSION=3.8
+        - MB_ML_VER=2014
+        #- CONFIG_PATH: "config_ilp64.sh"
         - DEBUG_PRINT=1
         - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
     - os: linux
       arch: arm64
       env:
         - PLAT=aarch64
-        - MB_ML_VER=2014
         - MB_PYTHON_VERSION=3.9
+        - MB_ML_VER=2014
+        #- CONFIG_PATH: "config_ilp64.sh"
         - DEBUG_PRINT=1
         - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,7 @@ jobs:
         py_3.7_64:
           PYTHON_VERSION: "3.7.x"
           PYTHON_ARCH: 'x64'
+          NPY_USE_BLAS_ILP64: 1
           BITS: 64
         py_3.8_32:
           PYTHON_VERSION: "3.8.x"
@@ -34,6 +35,7 @@ jobs:
         py_3.8_64:
           PYTHON_VERSION: "3.8.x"
           PYTHON_ARCH: 'x64'
+          NPY_USE_BLAS_ILP64: 1
           BITS: 64
         py_3.9_32:
           PYTHON_VERSION: "3.9.x"
@@ -42,6 +44,7 @@ jobs:
         py_3.9_64:
           PYTHON_VERSION: "3.9.x"
           PYTHON_ARCH: 'x64'
+          NPY_USE_BLAS_ILP64: 1
           BITS: 64
 
   - template: azure/posix.yml
@@ -54,38 +57,41 @@ jobs:
           MB_PYTHON_VERSION: "pypy3.7-7.3.5"
           AZURE_PYTHON_VERSION: "3.7"
           MB_ML_VER: "2014"
+          CONFIG_PATH: "config_ilp64.sh"
           DOCKER_TEST_IMAGE: multibuild/xenial_{PLAT}
 
         py_3.7_32:
           MB_PYTHON_VERSION: "3.7"
           PLAT: "i686"
           MB_ML_VER: "2014"
-          ENV_VARS_PATH: "env_vars_32.sh"
+          CONFIG_PATH: "config_ilp64.sh"
           DOCKER_TEST_IMAGE: "multibuild/xenial_{PLAT}"
         py_3.7_64:
           MB_PYTHON_VERSION: "3.7"
           MB_ML_VER: "2014"
+          CONFIG_PATH: "config_ilp64.sh"
 
         py_3.8_32:
           MB_PYTHON_VERSION: "3.8"
           PLAT: "i686"
           MB_ML_VER: "2014"
-          ENV_VARS_PATH: "env_vars_32.sh"
+          CONFIG_PATH: "config_ilp64.sh"
           DOCKER_TEST_IMAGE: "multibuild/xenial_{PLAT}"
         py_3.8_64:
           MB_PYTHON_VERSION: "3.8"
           MB_ML_VER: "2014"
+          CONFIG_PATH: "config_ilp64.sh"
 
         py_3.9_32:
           MB_PYTHON_VERSION: "3.9"
           PLAT: "i686"
           MB_ML_VER: "2014"
-          ENV_VARS_PATH: "env_vars_32.sh"
+          CONFIG_PATH: "config_ilp64.sh"
           DOCKER_TEST_IMAGE: "multibuild/xenial_{PLAT}"
         py_3.9_64:
           MB_PYTHON_VERSION: "3.9"
           MB_ML_VER: "2014"
-          DOCKER_TEST_IMAGE: "multibuild/xenial_{PLAT}"
+          CONFIG_PATH: "config_ilp64.sh"
 
   - template: azure/posix.yml
     parameters:
@@ -94,14 +100,19 @@ jobs:
       matrix:
         py_3.7_64:
           MB_PYTHON_VERSION: "3.7"
+          CONFIG_PATH: "config_ilp64.sh"
         py_3.8_64:
           MB_PYTHON_VERSION: "3.8"
+          CONFIG_PATH: "config_ilp64.sh"
         py_3.9_64:
           MB_PYTHON_VERSION: "3.9"
+          CONFIG_PATH: "config_ilp64.sh"
 
         py_3.8_universal2:
           MB_PYTHON_VERSION: "3.8"
           PLAT: universal2
+          #CONFIG_PATH: "config_ilp64.sh"
         py_3.9_universal2:
           MB_PYTHON_VERSION: "3.9"
           PLAT: universal2
+          #CONFIG_PATH: "config_ilp64.sh"

--- a/azure/windows.yml
+++ b/azure/windows.yml
@@ -46,7 +46,7 @@ jobs:
 
       - bash: |
           set -e
-          echo PYTHON $PYTHON_VERSION $PYTHON_ARCH
+          echo PYTHON $PYTHON_VERSION $PYTHON_ARCH $BITS $NPY_USE_BLAS_ILP64
           echo Build Reason: $BUILD_REASON
           python --version
           python -c "import struct; print(struct.calcsize('P') * 8)"
@@ -96,9 +96,14 @@ jobs:
           # mingw does not like. Instead copy it to a directory and set OPENBLAS
           target=$(python tools/openblas_support.py)
           mkdir -p openblas
-          echo Copying $target to openblas
           cp $target openblas
-          echo "##vso[task.setvariable variable=OPENBLAS]openblas"
+          ls openblas
+          if [ "$NPY_USE_BLAS_ILP64" == "1" ]; then
+              echo "##vso[task.setvariable variable=OPENBLAS64_]openblas"
+          else
+              echo "##vso[task.setvariable variable=OPENBLAS]openblas"
+          fi
+          popd
         displayName: Prepare the build
 
       - powershell: |

--- a/config_ilp64.sh
+++ b/config_ilp64.sh
@@ -4,6 +4,9 @@
 if [ $(uname) == "Linux" ]; then IS_LINUX=1; fi
 source gfortran-install/gfortran_utils.sh
 
+# Use 64 bit BLAS
+export NPY_USE_BLAS_ILP64
+
 function _build_wheel {
     build_libs
     build_bdist_wheel $@


### PR DESCRIPTION
Summary of current problems

-  Windows: Flaky, seem to depend on whether or not mingw gcc compiler is found by distutils. May be a distutils problem.
-  Mac: universal2 fails, seems to be a problem finding the downloaded ILP64 arm64 library.
-  Arm64 (travis): looks like a bug in the OpenBLAS library, hangs testing dot product. 

This PR does not enable ILP64 for universal2 and travis arm64 wheel builds, those problems are left for later PRs.