### PR TITLE
BUG: Windows and Linux build fixes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,7 +64,7 @@ jobs:
           MB_PYTHON_VERSION: "3.7"
           PLAT: "i686"
           MB_ML_VER: "2014"
-          CONFIG_PATH: "config_ilp64.sh"
+          ENV_VARS_PATH: "env_vars_32.sh"
           DOCKER_TEST_IMAGE: "multibuild/xenial_{PLAT}"
         py_3.7_64:
           MB_PYTHON_VERSION: "3.7"
@@ -75,7 +75,7 @@ jobs:
           MB_PYTHON_VERSION: "3.8"
           PLAT: "i686"
           MB_ML_VER: "2014"
-          CONFIG_PATH: "config_ilp64.sh"
+          ENV_VARS_PATH: "env_vars_32.sh"
           DOCKER_TEST_IMAGE: "multibuild/xenial_{PLAT}"
         py_3.8_64:
           MB_PYTHON_VERSION: "3.8"
@@ -86,7 +86,7 @@ jobs:
           MB_PYTHON_VERSION: "3.9"
           PLAT: "i686"
           MB_ML_VER: "2014"
-          CONFIG_PATH: "config_ilp64.sh"
+          ENV_VARS_PATH: "env_vars_32.sh"
           DOCKER_TEST_IMAGE: "multibuild/xenial_{PLAT}"
         py_3.9_64:
           MB_PYTHON_VERSION: "3.9"

--- a/azure/windows.yml
+++ b/azure/windows.yml
@@ -75,6 +75,7 @@ jobs:
 
       - powershell: |
           choco install -y mingw --forcex86 --force --version=7.3.0
+          refreshenv
         displayName: 'Install 32-bit mingw for 32-bit builds'
         condition: eq(variables['BITS'], 32)
 
@@ -97,12 +98,6 @@ jobs:
           target=$(python tools/openblas_support.py)
           mkdir -p openblas
           cp $target openblas
-          ls openblas
-          if [ "$NPY_USE_BLAS_ILP64" == "1" ]; then
-              echo "##vso[task.setvariable variable=OPENBLAS64_]openblas"
-          else
-              echo "##vso[task.setvariable variable=OPENBLAS]openblas"
-          fi
           popd
         displayName: Prepare the build
 
@@ -111,7 +106,11 @@ jobs:
               $env:CFLAGS = "-m32"
               $env:LDFLAGS = "-m32"
               $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
-              refreshenv
+          }
+          If ( Test-Path env:NPY_USE_BLAS_ILP64 ) {
+              $env:OPENBLAS64_ = "openblas"
+          } else {
+              $env:OPENBLAS = "openblas"
           }
           # Build the wheel
           pushd numpy


### PR DESCRIPTION
Small fixes:

- ENV_VARS_PATH was accidentally removed from 32 bit linux builds
- Improve azure/windows.yml script

This fixes the Windows openblas64_ builds' flakyness. They would randomly fail before.
