### PR TITLE
Append to instead of replace LICENSE.txt

### DIFF
--- a/azure/windows.yml
+++ b/azure/windows.yml
@@ -86,8 +86,8 @@ jobs:
           # a bit overkill, all we really need is cython
           python -m pip install --timeout=60 -r test_requirements.txt
 
-          # handle license
-          cp ../LICENSE_win32.txt LICENSE.txt
+          # append to license
+          cat ../LICENSE_win32.txt >> LICENSE.txt
 
           # handle _distributor_init.py
           PYTHONPATH=tools python -c "import openblas_support; openblas_support.make_init('numpy')"


### PR DESCRIPTION
Currently the license in the windows .whl distribution does not include the original BSD-3 licence.  See the attached [LICENSE.txt](https://github.com/MacPython/numpy-wheels/files/7017639/LICENSE.txt) found in `numpy-1.21.2-cp37-cp37m-win32` from PyPi.

It looks to me like this is because `LICENSE_win32.txt` replaces `LICENSE.txt` so I have instead changed it to append instead.

The licenses for the osx and linux wheels don't appear to have this issue