### PR TITLE
MAINT: Update for 3.10 on Mac

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/numpy/numpy.git
 [submodule "multibuild"]
 	path = multibuild
-	url = https://github.com/matthew-brett/multibuild
+	url = https://github.com/multi-build/multibuild
 [submodule "gfortran-install"]
 	path = gfortran-install
 	url = https://github.com/MacPython/gfortran-install.git

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,6 +84,9 @@ jobs:
         py_3.9_64:
           MB_PYTHON_VERSION: "3.9"
           CONFIG_PATH: "config_ilp64.sh"
+        py_3.10_64:
+          MB_PYTHON_VERSION: "3.10"
+          CONFIG_PATH: "config_ilp64.sh"
 
         py_3.8_universal2:
           MB_PYTHON_VERSION: "3.8"


### PR DESCRIPTION
- Change multibuild submodule to point to multi-built/multibuid instead
  of Matthew's fork in order to get latest merges.
- Update multibuild to HEAD of devel
- Add thin x86_64 thin wheel build for Mac.