### PR TITLE
Update Mac version from 10.9 to 10.14.

### DIFF
--- a/azure/posix.yml
+++ b/azure/posix.yml
@@ -49,7 +49,7 @@ jobs:
           # Platform variables used in multibuild scripts
           if [ `uname` == 'Darwin' ]; then
             echo "##vso[task.setvariable variable=TRAVIS_OS_NAME]osx"
-            echo "##vso[task.setvariable variable=MACOSX_DEPLOYMENT_TARGET]10.9"
+            echo "##vso[task.setvariable variable=MACOSX_DEPLOYMENT_TARGET]10.14"
           else
             echo "##vso[task.setvariable variable=TRAVIS_OS_NAME]linux"
           fi

--- a/env_vars.sh
+++ b/env_vars.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Environment variables for build
-MACOSX_DEPLOYMENT_TARGET=10.9
+MACOSX_DEPLOYMENT_TARGET=10.14
 CFLAGS="-std=c99 -fno-strict-aliasing"
 # Macos's linker doesn't support stripping symbols
 if [ "$(uname)" != "Darwin" ]; then

--- a/env_vars_32.sh
+++ b/env_vars_32.sh
@@ -3,7 +3,7 @@
 # The important difference from the 64-bit build is `-msse2` to
 # compile sse loops for ufuncs.
 set -x
-MACOSX_DEPLOYMENT_TARGET=10.9
+MACOSX_DEPLOYMENT_TARGET=10.14
 
 # Fails test_umath.TestAVXUfuncs with reciprocal on Azure
 # CFLAGS="-msse2 -std=c99 -fno-strict-aliasing"


### PR DESCRIPTION
This is needed because of changes in the azure provided Python 3.8 for
Mac.