### PR TITLE
Backport build fixes from main.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ jobs:
   - template: azure/windows.yml
     parameters:
       name: "windows2019"
-      vmImage: "windows-latest"
+      vmImage: "windows-2019"
       timeoutInMinutes: 90
       matrix:
         py_3.8_32:

--- a/azure/posix.yml
+++ b/azure/posix.yml
@@ -49,7 +49,7 @@ jobs:
           # Platform variables used in multibuild scripts
           if [ `uname` == 'Darwin' ]; then
             echo "##vso[task.setvariable variable=TRAVIS_OS_NAME]osx"
-            echo "##vso[task.setvariable variable=MACOSX_DEPLOYMENT_TARGET]10.9"
+            echo "##vso[task.setvariable variable=MACOSX_DEPLOYMENT_TARGET]10.14"
           else
             echo "##vso[task.setvariable variable=TRAVIS_OS_NAME]linux"
           fi

--- a/azure/set_vs_toolchain.cmd
+++ b/azure/set_vs_toolchain.cmd
@@ -1,0 +1,71 @@
+@@echo on
+REM set Visual Studio toolchain given bitness, VS year and toolchain number.
+IF [%1] == [] GOTO NoArgErr
+set VS_BITS=%1
+IF [%2] == [] GOTO NoArgErr
+set VS_YEAR=%2
+IF [%3] == [] GOTO NoArgErr
+set VS_TOOLCHAIN=%3
+
+
+REM Tools can come from any of Professional, Community, BuildTools or Enterprise install.
+if not exist "%VSINSTALLDIR%" (
+set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\%VS_YEAR%\Professional\"
+)
+if not exist "%VSINSTALLDIR%" (
+set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\%VS_YEAR%\Community\"
+)
+if not exist "%VSINSTALLDIR%" (
+set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\%VS_YEAR%\BuildTools\"
+)
+if not exist "%VSINSTALLDIR%" (
+set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\%VS_YEAR%\Enterprise\"
+)
+
+REM Discover the latest Windows SDK available.
+call :GetWin10SdkDir
+:: dir /ON here is sorting the list of folders, such that we use the latest one that we have
+for /F %%i in ('dir /ON /B "%WindowsSdkDir%\include\10.*"') DO (
+  SET WindowsSDKVer=%%~i
+)
+if errorlevel 1 (
+    echo "Didn't find any windows 10 SDK. I'm not sure if things will work, but let's try..."
+) else (
+    echo Windows SDK version found as: "%WindowsSDKVer%"
+)
+
+REM Set bitness, toolchain version and SDK.
+call "%VSINSTALLDIR%\VC\Auxiliary\Build\vcvars%1.bat" -vcvars_ver=%VS_TOOLCHAIN% %WindowsSDKVer%
+REM https://docs.python.org/3.9/distutils/apiref.html#module-distutils.msvccompiler
+REM or
+REM https://setuptools.pypa.io/en/latest/deprecated/distutils/apiref.html#module-distutils.msvccompiler
+REM Force our SDK, rather than the Python was built with.
+set DISTUTILS_USE_SDK=1
+set MSSdk=1
+
+REM All done, finish here.
+goto:eof
+
+REM Various subroutines.
+
+:GetWin10SdkDir
+call :GetWin10SdkDirHelper HKLM\SOFTWARE\Wow6432Node > nul 2>&1
+if errorlevel 1 call :GetWin10SdkDirHelper HKCU\SOFTWARE\Wow6432Node > nul 2>&1
+if errorlevel 1 call :GetWin10SdkDirHelper HKLM\SOFTWARE > nul 2>&1
+if errorlevel 1 call :GetWin10SdkDirHelper HKCU\SOFTWARE > nul 2>&1
+if errorlevel 1 exit /B 1
+exit /B 0
+
+:GetWin10SdkDirHelper
+@@REM `Get Windows 10 SDK installed folder`
+for /F "tokens=1,2*" %%i in ('reg query "%1\Microsoft\Microsoft SDKs\Windows\v10.0" /v "InstallationFolder"') DO (
+    if "%%i"=="InstallationFolder" (
+        SET WindowsSdkDir=%%~k
+    )
+)
+exit /B 0
+
+:NoArgErr
+echo "Need to specify input bitness, VS year and toolchain number"
+echo "e.g 64 2019 14.16"
+exit 1

--- a/azure/set_vs_toolchain.cmd
+++ b/azure/set_vs_toolchain.cmd
@@ -1,12 +1,18 @@
 @@echo on
 REM set Visual Studio toolchain given bitness, VS year and toolchain number.
+
+REM Parts of this file copied from:
+REM https://github.com/conda-forge/vc-feedstock/blob/7c0aa76218f369227d6a7fc78f981b100d68d50a/recipe/activate.bat
+REM licensed as follows:
+REM BSD-3-Clause
+REM Copyright conda-forge contributors
+
 IF [%1] == [] GOTO NoArgErr
 set VS_BITS=%1
 IF [%2] == [] GOTO NoArgErr
 set VS_YEAR=%2
 IF [%3] == [] GOTO NoArgErr
 set VS_TOOLCHAIN=%3
-
 
 REM Tools can come from any of Professional, Community, BuildTools or Enterprise install.
 if not exist "%VSINSTALLDIR%" (

--- a/azure/windows.yml
+++ b/azure/windows.yml
@@ -20,6 +20,13 @@ jobs:
       - checkout: self
         submodules: true
 
+      - task: BatchScript@1
+        inputs:
+          filename: azure/set_vs_toolchain.cmd
+          arguments: $(BITS) 2019 14.16
+          modifyEnvironment: True
+        displayName: Set VS toolchain version
+
       - task: UsePythonVersion@0
         inputs:
           versionSpec: $(PYTHON_VERSION)
@@ -122,6 +129,8 @@ jobs:
           popd
         displayName: Build wheel
       - bash: |
+          # Undo use specify VS build tools.
+          unset DISTUTILS_USE_SDK MSSdk
           set -ex
           source extra_functions.sh
           source config.sh

--- a/env_vars.sh
+++ b/env_vars.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Environment variables for build
-MACOSX_DEPLOYMENT_TARGET=10.9
+MACOSX_DEPLOYMENT_TARGET=10.14
 CFLAGS="-std=c99 -fno-strict-aliasing"
 # Macos's linker doesn't support stripping symbols
 if [ "$(uname)" != "Darwin" ]; then

--- a/env_vars_32.sh
+++ b/env_vars_32.sh
@@ -3,7 +3,7 @@
 # The important difference from the 64-bit build is `-msse2` to
 # compile sse loops for ufuncs.
 set -x
-MACOSX_DEPLOYMENT_TARGET=10.9
+MACOSX_DEPLOYMENT_TARGET=10.14
 
 # Fails test_umath.TestAVXUfuncs with reciprocal on Azure
 # CFLAGS="-msse2 -std=c99 -fno-strict-aliasing"


### PR DESCRIPTION
This is a backport of #146, #149, #150 in order to fix the following:

- Change the vs2019 tool chain to 1.41 to allow downstream extensions built with 1.41 to link with NumPy provided libraries.
- Update the Mac os version from 10.9 to 10.14. That is the oldest Apple supported version and is needed due to azure updates.