### PR TITLE
stop the azure cron job now that cibuildwheel is uploading

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,11 +1,11 @@
-schedules:
-- cron: "27 3 * * 0"
-  # 3:27am UTC every Sunday
-  displayName: Weekly build
-  branches:
-    include:
-    - main
-  always: true
+#schedules:
+#- cron: "27 3 * * 0"
+#  # 3:27am UTC every Sunday
+#  displayName: Weekly build
+#  branches:
+#    include:
+#    - main
+#  always: true
 
 pr:
 - main


### PR DESCRIPTION
We still need this repo for the release, but can stop the weekly cron job since the main repo is now running a cron job via cibuildwheel. If this PR is accepted, I will also stop the travis cron job (via the travis GUI).