### PR TITLE
MAINT: Update Cython versions to 0.29.30.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ env:
         - REPO_DIR=numpy
         # Also see CRON_COMMIT below
         - BUILD_COMMIT=main
-        - BUILD_DEPENDS=cython==0.29.28
+        - BUILD_DEPENDS=cython==0.29.30
         - TEST_DEPENDS="pytest hypothesis cffi pytz"
         # Commit when running from cron job
         - CRON_COMMIT=main

--- a/azure/posix.yml
+++ b/azure/posix.yml
@@ -12,7 +12,7 @@ jobs:
     variables:
       REPO_DIR: "numpy"
       PLAT: "x86_64"
-      CYTHON_BUILD_DEP: "cython==0.29.24"
+      CYTHON_BUILD_DEP: "cython==0.29.30"
       NIGHTLY_BUILD_COMMIT: "main"
       TEST_DEPENDS: "pytest hypothesis cffi pytz"
       JUNITXML: "test-data.xml"

--- a/env_vars.sh
+++ b/env_vars.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Environment variables for build
-MACOSX_DEPLOYMENT_TARGET=10.14
+MACOSX_DEPLOYMENT_TARGET=10.15
 CFLAGS="-std=c99 -fno-strict-aliasing"
 # Macos's linker doesn't support stripping symbols
 if [ "$(uname)" != "Darwin" ]; then

--- a/env_vars_32.sh
+++ b/env_vars_32.sh
@@ -3,7 +3,7 @@
 # The important difference from the 64-bit build is `-msse2` to
 # compile sse loops for ufuncs.
 set -x
-MACOSX_DEPLOYMENT_TARGET=10.14
+MACOSX_DEPLOYMENT_TARGET=10.15
 
 # Fails test_umath.TestAVXUfuncs with reciprocal on Azure
 # CFLAGS="-msse2 -std=c99 -fno-strict-aliasing"


### PR DESCRIPTION
Keep main updated in case we need to fall back to it. @mattip Do we still need travis for aarch64?