### PR TITLE
BUG: Fix missing typing_extensions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,11 @@ env:
         # Also see CRON_COMMIT below
         - BUILD_COMMIT=main
         - BUILD_DEPENDS=cython==0.29.30
-        - TEST_DEPENDS="pytest hypothesis cffi pytz"
+        - TEST_DEPENDS="\
+              pytest cffi pytz \
+              hypothesis==6.48.0 \
+              mypy==0.950 \
+              typing_extensions>=4.2.0"
         # Commit when running from cron job
         - CRON_COMMIT=main
         - EXTRA_ARGV="'--disable-pytest-warnings'"

--- a/azure/posix.yml
+++ b/azure/posix.yml
@@ -14,7 +14,12 @@ jobs:
       PLAT: "x86_64"
       CYTHON_BUILD_DEP: "cython==0.29.30"
       NIGHTLY_BUILD_COMMIT: "main"
-      TEST_DEPENDS: "pytest hypothesis cffi pytz"
+      TEST_DEPENDS: "\
+            pytest cffi pytz \
+            hypothesis==6.48.0 \
+            mypy==0.950 \
+            typing_extensions>=4.2.0"
+
       JUNITXML: "test-data.xml"
       TEST_DIR: "tmp_for_test"
     strategy:

--- a/extra_functions.sh
+++ b/extra_functions.sh
@@ -17,7 +17,7 @@ function setup_test_venv {
         PIP_CMD="$PYTHON_EXE -m pip"
         python -m pip install --upgrade pip wheel
         if [ "$TEST_DEPENDS" != "" ]; then
-            pip install $TEST_DEPENDS
+            python -m pip install $TEST_DEPENDS
         fi
     fi
 }


### PR DESCRIPTION
Wheels builds on aarch64 have been failing for a long time. @mattip Ping, it looks like you made the last change here. Should we be using cython 0.29.32?